### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a Model Context Protocol (MCP) tool that allows Claude to interact with Microsoft Outlook for macOS.
 
+<a href="https://glama.ai/mcp/servers/0j71n92wnh">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/0j71n92wnh/badge" alt="Claude Outlook Tool MCP server" />
+</a>
+
 ## Features
 
 - Mail:


### PR DESCRIPTION
This PR adds a badge for the [Claude Outlook MCP Tool](https://glama.ai/mcp/servers/0j71n92wnh) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/0j71n92wnh">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/0j71n92wnh/badge" alt="Claude Outlook Tool MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.